### PR TITLE
Manually merge pan-'s work

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,0 +1,1 @@
+https://github.com/ARMmbed/mbed-os/#9111aa4c2dc74fd9bc29f6c37a26489c09cf8a68

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -1,0 +1,6 @@
+{
+    "macros": [
+        "NDEBUG=1",
+        "MBEDTLS_USER_CONFIG_FILE=\"mbedtls_config.h\""
+    ]
+}

--- a/source/EntropySource/EntropySource.cpp
+++ b/source/EntropySource/EntropySource.cpp
@@ -15,7 +15,7 @@
  */
 #include "EntropySource.h"
 
-#ifndef TARGET_NRF51822 /* Persistent storage supported on nrf51 platforms */
+#if !defined(TARGET_NRF51822) && !defined(TARGET_MCU_NRF52832) /* Persistent storage supported on nrf51 platforms */
     /**
      * When not using an nRF51-based target then entropy source is currently unimplemented.
      */
@@ -23,5 +23,11 @@
 
     int eddystoneRegisterEntropySource(	mbedtls_entropy_context* ctx) { 
       return 1;
+    }
+
+    int eddystoneEntropyPoll( void *data,
+                        unsigned char *output, size_t len, size_t *olen )
+    {
+        return( 1 );
     }
 #endif /* #ifdef TARGET_NRF51822 */

--- a/source/EntropySource/EntropySource.h
+++ b/source/EntropySource/EntropySource.h
@@ -1,25 +1,11 @@
-/*
-
 #ifndef __ENTROPY_SOURCE_H__
 #define __ENTROPY_SOURCE_H__
-#include "stddef.h"
-
-    int eddystoneEntropyPoll( void *data,
-                        unsigned char *output, size_t len, size_t *olen );
-                        
-#endif // #ifndef __BLE_CONFIG_PARAMS_PERSISTENCE_H__
-*/
-
-#ifndef __ENTROPY_SOURCE_H__
-#define __ENTROPY_SOURCE_H__
-
 #include <stddef.h>
 #include <mbedtls/entropy.h>
 
 int eddystoneRegisterEntropySource(	mbedtls_entropy_context* ctx);
 
 int eddystoneEntropyPoll( void *data,
-                        unsigned char *output, size_t len, size_t *olen );
+                    unsigned char *output, size_t len, size_t *olen );
 
-                        
-#endif /* #ifndef __BLE_CONFIG_PARAMS_PERSISTENCE_H__*/
+#endif // __ENTROPY_SOURCE_H__

--- a/source/EntropySource/nRFEntropySource/nRFEntropySource.cpp
+++ b/source/EntropySource/nRFEntropySource/nRFEntropySource.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 #include "../EntropySource.h"
-#define TARGET_NRF51822
-#ifdef TARGET_NRF51822 /* Persistent storage supported on nrf51 platforms */
+
+#if defined(TARGET_NRF51822) || defined(TARGET_MCU_NRF52832) /* Persistent storage supported on nrf51 platforms */
 
 #include "nrf_soc.h"
 #include "nrf_error.h"
@@ -28,7 +28,7 @@
 int eddystoneEntropyPoll(void *data, unsigned char *output, size_t len, size_t *olen)
 {
     uint8_t bytes_available = 0;
-    
+
     // get the number of random bytes available
     if (sd_rand_application_bytes_available_get(&bytes_available) != NRF_SUCCESS) {
         return MBEDTLS_ERR_ENTROPY_SOURCE_FAILED;
@@ -51,18 +51,17 @@ int eddystoneEntropyPoll(void *data, unsigned char *output, size_t len, size_t *
     return 0;
 }
 
+int eddystoneRegisterEntropySource(	mbedtls_entropy_context* ctx) {
+    uint8_t pool_capacity;
+    sd_rand_application_pool_capacity_get(&pool_capacity);
 
-int eddystoneRegisterEntropySource(	mbedtls_entropy_context* ctx) { 
-  uint8_t pool_capacity;
-  sd_rand_application_pool_capacity_get(&pool_capacity);
-
-  return mbedtls_entropy_add_source(
-    ctx, 
-    eddystoneEntropyPoll, // entropy source function
-    NULL,                 // entropy source data, NULL in this case
-    pool_capacity,        //  minimum number of bytes the entropy pool should wait on from this callback before releasing entropy
-    MBEDTLS_ENTROPY_SOURCE_STRONG
-  );
+    return mbedtls_entropy_add_source(
+        ctx,
+        eddystoneEntropyPoll, // entropy source function
+        NULL,                 // entropy source data, NULL in this case
+        pool_capacity,        //  minimum number of bytes the entropy pool should wait on from this callback before releasing entropy
+        MBEDTLS_ENTROPY_SOURCE_STRONG
+    );
 }
 
 #endif /* #ifdef TARGET_NRF51822 */

--- a/source/EventQueue/PriorityQueue.h
+++ b/source/EventQueue/PriorityQueue.h
@@ -299,6 +299,7 @@ public:
 				--used_nodes_count;
 				return true;
 			}
+			current = current->next;
 		}
 		return false;
 	}

--- a/source/EventQueue/util/NordicCriticalSectionLock.h
+++ b/source/EventQueue/util/NordicCriticalSectionLock.h
@@ -29,7 +29,9 @@
 #include "nrf_soc.h"
 #include "nrf_sdm.h"
 #include "nrf_nvic.h"
-
+extern "C" {
+#include "softdevice_handler.h"
+}
 namespace util {
 
 /** RAII object for disabling, then restoring, interrupt state
@@ -63,8 +65,7 @@ public:
         } else {
           // otherwise, use soft device routine if softdevice is running or disable
           // the irq if softdevice is not running
-          uint8_t sd_enabled;
-          if((sd_softdevice_is_enabled(&sd_enabled) == NRF_SUCCESS) && sd_enabled == 1) {
+          if(softdevice_handler_isEnabled()) {
             _use_softdevice_routine = true;
             sd_nvic_critical_region_enter(&_sd_state);
           } else {


### PR DESCRIPTION
This PR only contains Vincent's commits from https://github.com/pan-/BLE_EddystoneService.

However, some new stuff regarding aes_eax.cpp was added, and thus does not compile out of the box. With the following diff I can make it compile and link:

``` diff
diff --git a/source/aes_eax.cpp b/source/aes_eax.cpp
index 240d9f7..e46683c 100644
--- a/source/aes_eax.cpp
+++ b/source/aes_eax.cpp
@@ -21,7 +21,7 @@
 // set defines before loading aes.h
 #define MBEDTLS_CIPHER_MODE_CBC
 #define MBEDTLS_CIPHER_MODE_CTR
-#include "mbedtls/aes.h"
+#include "aes.h"

 #define EDDY_ERR_EAX_AUTH_FAILED    -0x000F /**< Authenticated decryption failed. */

diff --git a/source/mbedtls_config.h b/source/mbedtls_config.h
index 0809241..215671e 100644
--- a/source/mbedtls_config.h
+++ b/source/mbedtls_config.h
@@ -7,9 +7,10 @@
 #define MBEDTLS_HAVE_TIME
 #undef  MBEDTLS_HAVE_TIME_DATE

-#undef  MBEDTLS_CIPHER_MODE_CBC
+// #undef  MBEDTLS_CIPHER_MODE_CBC
 #undef  MBEDTLS_CIPHER_PADDING_PKCS7
 #undef  MBEDTLS_REMOVE_ARC4_CIPHERSUITES
+#define MBEDTLS_CIPHER_MODE_CTR

 /* mbed TLS feature support */
 #define MBEDTLS_ECP_DP_SECP256R1_ENABLED
```

However... This does not run on the NRF51_DK. It does run on the NRF52-DK, so I think that by adding even more things (aes_eax related things) we run out of memory again, as Vincent's branch runs fine on nRF51...
