### PR TITLE
Fork mbed os

### DIFF
--- a/.mbedignore
+++ b/.mbedignore
@@ -1,0 +1,7 @@
+mbed-os/rtos/*
+mbed-os/features/FEATURE_CLIENT/*
+mbed-os/features/FEATURE_COMMON_PAL/*
+mbed-os/features/FEATURE_UVISOR/*
+mbed-os/features/frameworks/*
+mbed-os/features/net/*
+mbed-os/features/storage/*

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#9111aa4c2dc74fd9bc29f6c37a26489c09cf8a68
+https://github.com/pan-/mbed/#9111aa4c2dc74fd9bc29f6c37a26489c09cf8a68

--- a/source/PersistentStorageHelper/ConfigParamsPersistence.cpp
+++ b/source/PersistentStorageHelper/ConfigParamsPersistence.cpp
@@ -16,7 +16,7 @@
 
 #include "ConfigParamsPersistence.h"
 
-#ifndef TARGET_NRF51822 /* Persistent storage supported on nrf51 platforms */
+#if !defined(TARGET_NRF51822) && !defined(TARGET_NRF52832) /* Persistent storage supported on nrf51 platforms */
     /**
      * When not using an nRF51-based target then persistent storage is not available.
      */

--- a/source/PersistentStorageHelper/nrfPersistentStorageHelper/nrfConfigParamsPersistence.cpp
+++ b/source/PersistentStorageHelper/nrfPersistentStorageHelper/nrfConfigParamsPersistence.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#ifdef TARGET_NRF51822 /* Persistent storage supported on nrf51 platforms */
+#if defined(TARGET_NRF51822) || defined(TARGET_NRF52832) /* Persistent storage supported on nrf51 platforms */
 
 extern "C" {
     #include "pstorage.h"


### PR DESCRIPTION
This PR includes three major changes: 
- The RTOS is not built anymore with this application. The RTOS was never used by this application (monothreaded). It's inclusion has just downsides in terms of memory consumption and efficiency.

With the RTOS: 

```
+----------------------+--------+-------+-------+
| Module               |  .text | .data |  .bss |
+----------------------+--------+-------+-------+
| Fill                 |    250 |     3 |    44 |
| Misc                 |  65918 |  2244 |  2994 |
| features/FEATURE_BLE |  15728 |     9 |   532 |
| features/frameworks  |   4039 |    84 |   856 |
| features/mbedtls     |  31097 |     4 |     0 |
| hal/common           |   2796 |     4 |   333 |
| hal/targets          |  14264 |     0 |  1423 |
| rtos/rtos            |    131 |     4 |     0 |
| rtos/rtx             |   5671 |    20 |  4226 |
| Subtotals            | 139894 |  2372 | 10408 |
+----------------------+--------+-------+-------+
```

without the rtos (NRF51_DK: 

```
+----------------------+--------+-------+------+
| Module               |  .text | .data | .bss |
+----------------------+--------+-------+------+
| Fill                 |    198 |     7 |   38 |
| Misc                 |  64751 |  2240 | 2994 |
| features/FEATURE_BLE |  15728 |     9 |  532 |
| features/mbedtls     |  31097 |     4 |    0 |
| hal/common           |   2006 |     4 |  285 |
| hal/targets          |  13946 |     0 | 1415 |
| Subtotals            | 127726 |  2264 | 5264 |
+----------------------+--------+-------+------+
```

Basically 20K of ROM and 5K of RAM saved.
-  To support custom targets, the pointer to mbed-os has been switch to a fork of mbed-os, To point to another repo, change the URL and # in mbed-os.lib.
- Enable persistence support for the NRF52. 
