### PR TITLE
Remove serial

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/pan-/mbed/#60c2e6f9ee3c24d93cd8929078a2664f6c99f077
+https://github.com/pan-/mbed/#f41155284b8605704de53afd337c4316e61cc528

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -3,5 +3,10 @@
         "NDEBUG=1",
         "MBEDTLS_USER_CONFIG_FILE=\"mbedtls_config.h\"",
         "OS_MAINSTKSIZE=1024"
-    ]
+    ], 
+    "target_overrides": {
+            "*": {
+                    "core.stdio-flush-at-exit": false
+            }
+    }
 }

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -232,9 +232,9 @@ void app_start(int, char *[])
 
 #ifdef NO_LOGGING
     /* Tell standard C library to not allocate large buffers for these streams */
-    setbuf(stdout, NULL);
-    setbuf(stderr, NULL);
-    setbuf(stdin, NULL);
+    // setbuf(stdout, NULL);
+    // setbuf(stderr, NULL);
+    // setbuf(stdin, NULL);
 #endif
 
 #ifndef NO_4SEC_START_DELAY
@@ -272,37 +272,6 @@ int main() {
     }
 
     return 0;
-}
-
-// *WARNING* HACK
-// avoid unecessary code to be pulled in,
-// should be fixed by mbed-os latter
-extern "C" {
-
-#if defined(TOOLCHAIN_GCC_ARM) || defined(TOOLCHAIN_GCC_CR)
-void exit(int) {
-    while(true) {
-    }
-}
-#endif
-
-int __aeabi_atexit(void *object, void (*dtor)(void* /*this*/), void *handle) {
-    return 0;
-}
-
-int __cxa_atexit(void (*dtor)(void* /*this*/), void *object, void *handle) {
-    return 0;
-}
-
-void __register_exitproc() {
-}
-
-void __call_exitprocs(int, void *f) {
-}
-
-void __cxa_finalize(void *handle) {
-}
-
 }
 
 


### PR DESCRIPTION
This patch remove any hidden occurrence to the serial peripheral when `NO_LOGGING` is defined in `Eddystone_config.h`.

In the process, patches have been backported to mbed-os. 
It saves 2K of RAM.
