### PR TITLE
Update reference to mbed-os tree.

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/pan-/mbed/#f41155284b8605704de53afd337c4316e61cc528
+https://github.com/pan-/mbed/#68dd6d84420ac1f589d0c34103ee73b683438919


### PR DESCRIPTION
The new reference contains a fix for a bug causing any NRF51 based target to hang
after 511 seconds if the RTOS is not present.
