### PR TITLE
Switch from pstorage to fstorage

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#aeabcc947294f2a6cbe1e808c030779c7c460f10
+https://github.com/ARMmbed/mbed-os/#8d21974ba35e04c4854e5090c0f8283171664175

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -3,10 +3,10 @@
         "NDEBUG=1",
         "MBEDTLS_USER_CONFIG_FILE=\"mbedtls_config.h\"",
         "OS_MAINSTKSIZE=1024"
-    ], 
+    ],
     "target_overrides": {
-            "*": {
-                    "platform.stdio-flush-at-exit": false
-            }
+        "*": {
+            "platform.stdio-flush-at-exit": false
+        }
     }
 }

--- a/source/PersistentStorageHelper/nrfPersistentStorageHelper/nrfConfigParamsPersistence.cpp
+++ b/source/PersistentStorageHelper/nrfPersistentStorageHelper/nrfConfigParamsPersistence.cpp
@@ -17,7 +17,7 @@
 #if defined(TARGET_NRF51822) || defined(TARGET_NRF52832) /* Persistent storage supported on nrf51 platforms */
 
 extern "C" {
-    #include "pstorage.h"
+    #include "fstorage.h"
 }
 
 #include "nrf_error.h"
@@ -38,55 +38,52 @@ struct PersistentParams_t {
 
 /**
  * The following is a module-local variable to hold configuration parameters for
- * short periods during flash access. This is necessary because the pstorage
+ * short periods during flash access. This is necessary because the fstorage
  * APIs don't copy in the memory provided as data source. The memory cannot be
  * freed or reused by the application until this flash access is complete. The
  * load and store operations in this module initialize persistentParams and then
- * pass it on to the 'pstorage' APIs.
+ * pass it on to the 'fstorage' APIs.
  */
 static PersistentParams_t persistentParams;
 
-static pstorage_handle_t pstorageHandle;
-
 /**
- * Dummy callback handler needed by Nordic's pstorage module. This is called
+ * Dummy callback handler needed by Nordic's fstorage module. This is called
  * after every flash access.
  */
-static void pstorageNotificationCallback(pstorage_handle_t *p_handle,
-                                         uint8_t            op_code,
-                                         uint32_t           result,
-                                         uint8_t           *p_data,
-                                         uint32_t           data_len)
+static void fs_evt_handler(fs_evt_t const * const evt, fs_ret_t result)
 {
     /* Supress compiler warnings */
-    (void) p_handle;
-    (void) op_code;
+    (void) evt;
     (void) result;
-    (void) p_data;
-    (void) data_len;
+}
 
-    /* APP_ERROR_CHECK(result); */
+FS_REGISTER_CFG(fs_config_t fs_config) = {
+    NULL,              // Begin pointer (set by fs_init)
+    NULL,              // End pointer (set by fs_init)
+    &fs_evt_handler,   // Function for event callbacks.
+    1,                 // Number of physical flash pages required.
+    0xFE               // Priority for flash usage.
+};
+
+
+void loadPersistentParams(void) {
+    // copy from flash into persistent params struct
+    memcpy(&persistentParams, fs_config.p_start_addr, sizeof(PersistentParams_t));
 }
 
 /* Platform-specific implementation for persistence on the nRF5x. Based on the
- * pstorage module provided by the Nordic SDK. */
+ * fstorage module provided by the Nordic SDK. */
 bool loadEddystoneServiceConfigParams(EddystoneService::EddystoneParams_t *paramsP)
 {
-    static bool pstorageInitied = false;
-    if (!pstorageInitied) {
-        pstorage_init();
-
-        static pstorage_module_param_t pstorageParams = {
-            .cb          = pstorageNotificationCallback,
-            .block_size  = sizeof(PersistentParams_t),
-            .block_count = 1
-        };
-        pstorage_register(&pstorageParams, &pstorageHandle);
-        pstorageInitied = true;
+    static bool fstorageInited = false;
+    if (!fstorageInited) {
+        fs_ret_t ret = fs_init();
+        fstorageInited = true;
     }
 
-    if ((pstorage_load(reinterpret_cast<uint8_t *>(&persistentParams), &pstorageHandle, sizeof(PersistentParams_t), 0) != NRF_SUCCESS) ||
-        (persistentParams.persistenceSignature != PersistentParams_t::MAGIC)) {
+    loadPersistentParams();
+
+    if ((persistentParams.persistenceSignature != PersistentParams_t::MAGIC)) {
         // On failure zero out and let the service reset to defaults
         memset(paramsP, 0, sizeof(EddystoneService::EddystoneParams_t));
         return false;
@@ -97,44 +94,54 @@ bool loadEddystoneServiceConfigParams(EddystoneService::EddystoneParams_t *param
 }
 
 /* Platform-specific implementation for persistence on the nRF5x. Based on the
- * pstorage module provided by the Nordic SDK. */
+ * fstorage module provided by the Nordic SDK. */
 void saveEddystoneServiceConfigParams(const EddystoneService::EddystoneParams_t *paramsP)
 {
     memcpy(&persistentParams.params, paramsP, sizeof(EddystoneService::EddystoneParams_t));
     if (persistentParams.persistenceSignature != PersistentParams_t::MAGIC) {
+        printf("store %08lx\n", persistentParams.persistenceSignature);
+
         persistentParams.persistenceSignature = PersistentParams_t::MAGIC;
-        pstorage_store(&pstorageHandle,
-                       reinterpret_cast<uint8_t *>(&persistentParams),
-                       sizeof(PersistentParams_t),
-                       0 /* offset */);
     } else {
-        pstorage_update(&pstorageHandle,
-                        reinterpret_cast<uint8_t *>(&persistentParams),
-                        sizeof(PersistentParams_t),
-                        0 /* offset */);
+        printf("update %08lx\n", persistentParams.persistenceSignature);
+
+        fs_erase(&fs_config, fs_config.p_start_addr, sizeof(PersistentParams_t) / 4);
     }
+
+    fs_store(&fs_config,
+             fs_config.p_start_addr,
+             reinterpret_cast<uint32_t *>(&persistentParams),
+             sizeof(PersistentParams_t) / 4);
 }
 
 /* Saves only the TimeParams (a subset of Config Params) for speed/power efficiency
  * Platform-specific implementation for persistence on the nRF5x. Based on the
- * pstorage module provided by the Nordic SDK. */
+ * fstorage module provided by the Nordic SDK. */
 void saveEddystoneTimeParams(const TimeParams_t *timeP)
 {
     // Copy the time params object to the main datastructure
     memcpy(&persistentParams.params.timeParams, timeP, sizeof(TimeParams_t));
-    // Test if this is the first pstorage update, or an update
+
+    // Test if this is the first fstorage update, or an update
     if (persistentParams.persistenceSignature != PersistentParams_t::MAGIC) {
         persistentParams.persistenceSignature = PersistentParams_t::MAGIC;
-        pstorage_store(&pstorageHandle,
-                       reinterpret_cast<uint8_t *>(&persistentParams),
-                       sizeof(TimeParams_t),
-                       offsetof(PersistentParams_t, params.timeParams) /* offset */);  
     } else {
-        pstorage_update(&pstorageHandle,
-                        reinterpret_cast<uint8_t *>(&persistentParams),
-                        sizeof(TimeParams_t),
-                        offsetof(PersistentParams_t, params.timeParams) /* offset */); 
+        printf("erasing from %p... %d bytes\n", fs_config.p_start_addr + offsetof(PersistentParams_t, params),
+            sizeof(TimeParams_t) / 4);
+
+        fs_erase(&fs_config,
+                 fs_config.p_start_addr + offsetof(PersistentParams_t, params) /* offset */,
+                 sizeof(TimeParams_t) / 4);
     }
+
+    printf("storing at %p, bytes %d\n",
+        fs_config.p_start_addr + offsetof(PersistentParams_t, params),
+        sizeof(TimeParams_t) / 4);
+
+    fs_store(&fs_config,
+             fs_config.p_start_addr + offsetof(PersistentParams_t, params) /* offset */,
+             reinterpret_cast<uint32_t *>(&persistentParams.params),
+             sizeof(TimeParams_t) / 4);
 }
 
 #endif /* #ifdef TARGET_NRF51822 */

--- a/source/PersistentStorageHelper/nrfPersistentStorageHelper/nrfConfigParamsPersistence.cpp
+++ b/source/PersistentStorageHelper/nrfPersistentStorageHelper/nrfConfigParamsPersistence.cpp
@@ -77,7 +77,7 @@ bool loadEddystoneServiceConfigParams(EddystoneService::EddystoneParams_t *param
 {
     static bool fstorageInited = false;
     if (!fstorageInited) {
-        fs_ret_t ret = fs_init();
+        fs_init();
         fstorageInited = true;
     }
 
@@ -99,12 +99,8 @@ void saveEddystoneServiceConfigParams(const EddystoneService::EddystoneParams_t 
 {
     memcpy(&persistentParams.params, paramsP, sizeof(EddystoneService::EddystoneParams_t));
     if (persistentParams.persistenceSignature != PersistentParams_t::MAGIC) {
-        printf("store %08lx\n", persistentParams.persistenceSignature);
-
         persistentParams.persistenceSignature = PersistentParams_t::MAGIC;
     } else {
-        printf("update %08lx\n", persistentParams.persistenceSignature);
-
         fs_erase(&fs_config, fs_config.p_start_addr, sizeof(PersistentParams_t) / 4);
     }
 
@@ -126,17 +122,10 @@ void saveEddystoneTimeParams(const TimeParams_t *timeP)
     if (persistentParams.persistenceSignature != PersistentParams_t::MAGIC) {
         persistentParams.persistenceSignature = PersistentParams_t::MAGIC;
     } else {
-        printf("erasing from %p... %d bytes\n", fs_config.p_start_addr + offsetof(PersistentParams_t, params),
-            sizeof(TimeParams_t) / 4);
-
         fs_erase(&fs_config,
                  fs_config.p_start_addr + offsetof(PersistentParams_t, params) /* offset */,
                  sizeof(TimeParams_t) / 4);
     }
-
-    printf("storing at %p, bytes %d\n",
-        fs_config.p_start_addr + offsetof(PersistentParams_t, params),
-        sizeof(TimeParams_t) / 4);
 
     fs_store(&fs_config,
              fs_config.p_start_addr + offsetof(PersistentParams_t, params) /* offset */,


### PR DESCRIPTION
@roywant @scottjenson This updates EddystoneBeacon to the new fstorage implementation in the Nordic SDK, also updates the project to mbed OS 5.4.5.

:1st_place_medal: 